### PR TITLE
Several settings fixes

### DIFF
--- a/components/ags/windows/settings/settings.js
+++ b/components/ags/windows/settings/settings.js
@@ -372,8 +372,8 @@ const NierSettingPane = (
     anchor: ["top", "left", "bottom"],
     exclusivity: "ignore",
     layer: "overlay",
-    focusable: true,
     visible: true,
+    keymode: "exclusive",
     
     setup: (self) =>
       Utils.timeout(1, () => {


### PR DESCRIPTION
- Limit app search results to 20 to improve performance.
Without this, typing in the search field (entry widget) is really sluggish for the first couple of characters on my laptop.

- Close settings after opening an app via the search bar.
- Automatically focus the entry widget to allow app searching.
- Fix keyboard input in settings.
Without `keymode: "exclusive"`, no key presses were registered at all in the settings screen.


