### PR TITLE
Fix for Hyprland 0.53 and add limb darkening to screen shader

### DIFF
--- a/components/foot.ini
+++ b/components/foot.ini
@@ -8,7 +8,7 @@
 # title=foot
 # locked-title=no
 
-font=BlexMono Nerd Font:size=16, font=Angelic:size=16
+font=BlexMono Nerd Font:size=16, font=Angelic Unimatrix:size=16
 # font-bold=<bold variant of regular font>
 # font-italic=<italic variant of regular font>
 # font-bold-italic=<bold+italic variant of regular font>

--- a/components/gridlines.frag
+++ b/components/gridlines.frag
@@ -6,7 +6,7 @@ in vec2 v_texcoord;
 uniform sampler2D tex;
 out vec4 fragColor;
 float width;
-float limbShading = 0.55;
+float limbShading = 0.45;
 float gridSpacing = 10.0;
 float gridShading = 0.97;
 

--- a/components/gridlines.frag
+++ b/components/gridlines.frag
@@ -1,18 +1,30 @@
 #version 300 es
+#define M_PI (3.14159265358979323846264338327950288)
 
 precision mediump float;
 in vec2 v_texcoord;
 uniform sampler2D tex;
 out vec4 fragColor;
+float width;
+float limbShading = 0.55;
+float gridSpacing = 10.0;
+float gridShading = 0.97;
 
 void main() {
 	vec4 pixColor = texture2D(tex, v_texcoord);
-	
-	if (int(mod(gl_FragCoord.x, 10.0)) == 0 ||
-        int(mod(gl_FragCoord.y, 10.0)) == 0) {
-			pixColor[0] *= 0.97;
-			pixColor[1] *= 0.97;
-			pixColor[2] *= 0.97;
+	vec2 size = vec2(textureSize(tex, 0));
+	width = size[0];
+
+	pixColor[0] *= limbShading*sin(M_PI*gl_FragCoord.x / width) + (1.0 - limbShading);
+	pixColor[1] *= limbShading*sin(M_PI*gl_FragCoord.x / width) + (1.0 - limbShading);
+	pixColor[2] *= limbShading*sin(M_PI*gl_FragCoord.x / width) + (1.0 - limbShading);
+
+	if (int(mod(gl_FragCoord.x, gridSpacing)) == 0 ||
+        int(mod(gl_FragCoord.y, gridSpacing)) == 0) {
+			pixColor[0] *= gridShading;
+			pixColor[1] *= gridShading;
+			pixColor[2] *= gridShading;
     }
+	
 	fragColor = pixColor;
 }

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ A rice inspired by `NieR:Automata` ui
     - ### Dependancies
         #### Arch
         > ```sh
-        > paru -S hyprland-git foot grim swww-git fish theme.sh sassc starship cava imagemagick gnome-bluetooth wl-clipboard libdbusmenu-gtk3 gnome-bluetooth-3.0 xorg-xrandr cpio cmake git meson gcc
+        > paru -S hyprland-git foot grim swww-git fish theme.sh sassc starship ttf-ibmplex-mono-nerd cava imagemagick gnome-bluetooth wl-clipboard libdbusmenu-gtk3 gnome-bluetooth-3.0 xorg-xrandr cpio cmake git meson gcc
         > ```
         #### STTT
         > install from https://github.com/flick0/sttt

--- a/theme.conf
+++ b/theme.conf
@@ -5,7 +5,7 @@ exec-once=pkill ags
 exec=sleep 1 && ags -c $yorha/components/ags/config.js
 exec=swww-daemon
 exec=sleep 1 && swww img $yorha/wallpapers/nier_light.png --transition-type simple --transition-step 255
-exec-once=hyprpm reload -nn
+exec-once=hyprpm reload -n
 
 bind=Super,o,exec,$DRUN
 

--- a/theme.conf
+++ b/theme.conf
@@ -21,13 +21,10 @@ $TERMFLOAT=$TERM --title fly_is_foot -w 1067x630
 
 source = $yorha/theme_nier_light.conf
 
-layerrule = ignorealpha 0.3, bg_settings
-layerrule = ignorealpha, side
-layerrule = ignorealpha, bar
-layerrule = ignorealpha, geom
-layerrule = blur, bg_settings
-layerrule = blur,side 
-layerrule = blur,bar
+layerrule = ignore_alpha 0.3, blur on, match:namespace bg_settings
+layerrule = ignore_alpha 0, blur on, match:namespace side
+layerrule = ignore_alpha 0, blur on, match:namespace bar
+layerrule = ignore_alpha 0, match:namespace geom
 
 decoration {
     rounding=0
@@ -78,5 +75,4 @@ animations {
 
 bind=Super,v,exec,ags -b player -t player
 
-windowrule=move 400 510,title:^(fly_is_foot)$
-
+windowrule = move (400) (510), match:title ^(fly_is_foot)$

--- a/theme.conf
+++ b/theme.conf
@@ -68,7 +68,7 @@ general {
 
 animations {
     enabled=1
-    bezier = in-out,.65,-0.01,0,.95
+    bezier = in-out,0.65,-0.01,0,0.95
     bezier = woa,0,0,0,1
     animation=windows,1,2,woa,popin
     animation=border,1,10,default


### PR DESCRIPTION
- Fix Hyprland config error for "invalid point" used to control the bezier curves, based on example from [Hyprland Wiki](https://wiki.hypr.land/Configuring/Animations/#example)
- Fix missing dependency for BlexMono Nerd Font
- Add limb darkening to screen shader